### PR TITLE
Prevent name clash

### DIFF
--- a/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3.yaml
@@ -106,9 +106,9 @@ wifi:
     password: s3box123
   on_connect:
     - script.execute:
-        id: initialize
+        id: box_initialize
     - script.wait:
-        id: initialize
+        id: box_initialize
     - script.execute:
         id: change_app_state
         nextState: ${APP_STATE_STATUS}
@@ -687,7 +687,7 @@ globals:
     initial_value: 'false'
 
 script:
-  - id: initialize
+  - id: box_initialize
     then:
       - lambda: |-
           id(ir_memory_button_codes).resize(4, "");


### PR DESCRIPTION
I had to make this change to prevent a compile error due to one of the libraries also using the `initialize` function name. FYI This is my config:

```yaml
substitutions:
  name: esp32-s3-box-3-05ab90
  friendly_name: ESP32 S3 Box 3 05ab90
packages:
  esphome.voice-assistant: github://jeremypoulter/ESP32-S3-Box-3-Voice-Assistant-Sensor-Dock/esp32-s3-box-3.yaml@master\
  
esphome:
  name: ${name}
  name_add_mac_suffix: false
  friendly_name: ${friendly_name}
api:
  encryption:
    key: ......

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  domain: .lan

```