### PR TITLE
ESPHome 2024.7.0 support

### DIFF
--- a/esp32-s3-box-3.yaml
+++ b/esp32-s3-box-3.yaml
@@ -237,7 +237,8 @@ media_player:
             - media_player.stop: adf_media_player
 
 micro_wake_word:
-  model: ${micro_wake_word_model}
+  models:
+    - ${micro_wake_word_model}
   on_wake_word_detected:
     - voice_assistant.start:
         wake_word: !lambda return wake_word;


### PR DESCRIPTION
Quick fix for breaking change the latest ESPHome release. A better fix may be to allow more wake words to be included, but at least this will allow compilation.